### PR TITLE
Fixes the function to find the correct Bible ID of a language

### DIFF
--- a/__tests__/resourcesHelpers.test.js
+++ b/__tests__/resourcesHelpers.test.js
@@ -1,0 +1,46 @@
+import fs from 'fs-extra'
+import { getBibleIdForLanguage, getGroupName } from '../src/helpers/resourcesHelpers'
+
+jest.mock('fs-extra')
+
+describe('tests getGroupName()', () => {
+  beforeAll(() => {
+    fs.__setMockFS({
+      '/en/translationHelps/translationAcademy/articles/test.md': '# test #\n\nThis is a test',
+    })
+  })
+
+  test('Get Group Name', () => {
+    const groupName = getGroupName('/en/translationHelps/translationAcademy/articles/test.md')
+    const expectedGroupName = 'test'
+    expect(groupName).toEqual(expectedGroupName)
+  })
+})
+
+describe('tests getBibleIdForLanguage()', () => {
+  beforeAll(() => {
+    fs.__setMockFS({
+      '/en/bibles': ['t4t', 'udb', 'ulb', 'ult', 'ust'],
+      '/hi/bibles': ['irv', 'udb', 'ulb'],
+      '/ru/bibles': ['rb1', 'rb2'],
+    })
+  })
+
+  test('Getting the English Bible', () => {
+    const bibleId = getBibleIdForLanguage('/en/bibles')
+    const expectedBibleId = 'ult'
+    expect(bibleId).toEqual(expectedBibleId)
+  })
+
+  test('Getting the Hindi Bible', () => {
+    const bibleId = getBibleIdForLanguage('/hi/bibles')
+    const expectedBibleId = 'irv'
+    expect(bibleId).toEqual(expectedBibleId)
+  })
+
+  test('Getting the Russian Bible', () => {
+    const bibleId = getBibleIdForLanguage('/ru/bibles')
+    const expectedBibleId = 'rb1'
+    expect(bibleId).toEqual(expectedBibleId)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsv-groupdata-parser",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsv-groupdata-parser",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Parses the translationNotes TSVs files to generate the GroupIndex and GroupData for the translationCore Desktop app.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers/resourcesHelpers.js
+++ b/src/helpers/resourcesHelpers.js
@@ -74,10 +74,11 @@ export function getBibleIdForLanguage(biblesPath) {
   if (bibleList.length === 0) {
     return 'ult'
   }
-  biblePrecedence.forEach(bibleId => {
+  for (let i = 0; i < biblePrecedence.length; ++i) {
+    const bibleId = biblePrecedence[i]
     if (bibleList.indexOf(bibleId) >= 0) {
       return bibleId
     }
-  })
+  }
   return bibleList[0]
 }


### PR DESCRIPTION
Made a mistake of returning in a forEach loop thinking it would return from the function, but does not. Fixed it and added tests.